### PR TITLE
Fix for  'portagegt': can't convert nil into String

### DIFF
--- a/lib/puppet/provider/package/portagegt.rb
+++ b/lib/puppet/provider/package/portagegt.rb
@@ -155,8 +155,10 @@ Puppet::Type.type(:package).provide(
 
 
       # We cannot specify these attributes unless we have a category as well
-      if category.nil? && optFlags.length != 0
-        Puppet.warning("Cannot apply #{funcName} for Package[#{name}] without a category")
+      if category.nil? 
+        if optFlags.length != 0
+          Puppet.warning("Cannot apply #{funcName} for Package[#{name}] without a category")
+        end
         next
       end
 


### PR DESCRIPTION
This fixes a case where someone (like me :) might not have defined a category, but still there is no warning in the log unless there was a optFlag. I suppose optFlag are portage specific things, as I noticed this error on packages where I specified things like require =>.
Which breaks the bank with the following message:

```
err: Could not prefetch package provider 'portagegt': can't convert nil into String
```
