### PR TITLE
environment variables for emerge

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -50,6 +50,14 @@ Using PortageGT should be pretty familiar to anyone already using puppet on Gent
 		ensure   => "2.00";
 	}
 
+# Custom Environment variables
+
+	package { "dev-db/mongodb":
+		keywords => "~amd64",
+		environment => "EPYTHON=python2.7",
+		ensure   => "2.2.2-r1";
+	}
+
 # Use flags
 ## String
 

--- a/lib/puppet/provider/package/portagegt.rb
+++ b/lib/puppet/provider/package/portagegt.rb
@@ -439,6 +439,18 @@ Puppet::Type.type(:package).provide(
       # We must install a specific version
       name = "=#{name}-#{should}"
     end
+    if envlist = @resource[:environment]
+      envlist = [envlist] unless envlist.is_a? Array
+      envlist.each do |setting|
+        if setting =~ /^(\w+)=((.|\n)+)$/
+          env_name = $1
+          value = $2
+          ENV[env_name] = value
+        else
+          warning "Cannot understand environment setting #{setting.inspect}"
+        end
+      end
+    end
 
     emerge name
   end

--- a/lib/puppet/type/package.rb
+++ b/lib/puppet/type/package.rb
@@ -16,6 +16,9 @@ module Puppet
 			desc "Package keywords"
 		end
 
+		newparam(:environment) do
+			desc "Package Environment"
+		end
 
 		# attributes with validation
 		newparam(:interval) do


### PR DESCRIPTION
Hi,

I added the ability to set environment variables before emerge, eg:

```
    package { "mongodb":
        ensure => "2.2.2-r1",
        environment => "EPYTHON=python2.7",
        category => "dev-db",
        keywords => "~amd64",
    }
```

(since mongodb won't compile with python 3.x)
pull request since I think it might be interesting to other people too eg:
http://projects.puppetlabs.com/issues/6400
although not Gentoo... but still...
