### PR TITLE
portagegt.rb: Change EIX_RUN_SYNC from boolean to int

### DIFF
--- a/lib/puppet/provider/package/portagegt.rb
+++ b/lib/puppet/provider/package/portagegt.rb
@@ -27,8 +27,11 @@ Puppet::Type.type(:package).provide(
   # Update eix database before each run
   EIX_RUN_UPDATE = true
 
-  # Run emerge --sync before each run
-  EIX_RUN_SYNC = true
+  # Minimum age of local portage tree, in seconds, 
+  # before re-syncing. -1 to never run eix-sync.
+  # Consider increasing if puppet is run multiple
+  # times per day to prevent rsync server bans.
+  EIX_RUN_SYNC = 0
 
   # Recompile package if use flags change
   RECOMPILE_USE_CHANGE = true
@@ -40,6 +43,7 @@ Puppet::Type.type(:package).provide(
   USE_DIR = '/etc/portage/package.use'
   KEYWORDS_DIR = '/etc/portage/package.keywords'
   PACKAGE_STATE_DIR = '/var/db/pkg'
+  TIMESTAMP_FILE = '/usr/portage/metadata/timestamp'
 
   #######################
   # Internal Structures #
@@ -102,14 +106,14 @@ Puppet::Type.type(:package).provide(
   def self.run_eix
 
     unless EIX_RUN_UPDATE
-      if EIX_RUN_SYNC
-        raise Puppet::Error.new('EIX_RUN_UPDATE must be true if EIX_RUN_SYNC is true')
+      if EIX_RUN_SYNC >= 0
+        raise Puppet::Error.new('EIX_RUN_UPDATE must be true if EIX_RUN_SYNC is not -1')
       end
       return
     end
 
     begin
-      if EIX_RUN_SYNC
+      if EIX_RUN_SYNC >= 0 && File.mtime(TIMESTAMP_FILE)+EIX_RUN_SYNC < Time.now
         eix_sync
       else
         eix_update

--- a/lib/puppet/provider/package/portagegt.rb
+++ b/lib/puppet/provider/package/portagegt.rb
@@ -27,7 +27,7 @@ Puppet::Type.type(:package).provide(
   # Update eix database before each run
   EIX_RUN_UPDATE = true
 
-  # Minimum age of local portage tree, in seconds, 
+  # Minimum age of local portage tree, in seconds,
   # before re-syncing. -1 to never run eix-sync.
   # Consider increasing if puppet is run multiple
   # times per day to prevent rsync server bans.
@@ -112,7 +112,7 @@ Puppet::Type.type(:package).provide(
       return
     end
 
-    if EIX_RUN_SYNC >= 0 && File.mtime(TIMESTAMP_FILE)+EIX_RUN_SYNC < Time.now
+    if EIX_RUN_SYNC >= 0 && File.mtime(TIMESTAMP_FILE) + EIX_RUN_SYNC < Time.now
       eix_sync
     else
       eix_update


### PR DESCRIPTION
Minimum age of portage tree before re-syncing. If PortageGT is used in situations where puppet is run multiple times per day, the ability to specify a minimum time between syncs can avoid bans from the rsync servers
